### PR TITLE
fix: export N_PREFIX

### DIFF
--- a/bin/git-cipher
+++ b/bin/git-cipher
@@ -32,6 +32,7 @@ N_EXE="$VENDOR/n/bin/n"
 N_PREFIX="$VENDOR/node"
 YARN_EXE="$VENDOR/yarn/bin/yarn"
 YARN_INTEGRITY="$ROOT/node_modules/.yarn-integrity"
+export N_PREFIX
 
 node() {
   "$N_EXE" exec "$NODE_VERSION" "$@"


### PR DESCRIPTION
This fixes an issue where the program would always fail with the following error:

```
[info]    Installing NodeJS 18.7.0
  installing : node-v18.7.0
       mkdir : /usr/local/n/versions/node/18.7.0
mkdir: /usr/local/n: Permission denied

  Error: sudo required (or change ownership, or define N_PREFIX)

zsh: exit 1
```

After the change `echo $N_PREFIX` still produces an empty line so we are not overwriting the users environment after the program exits.